### PR TITLE
FPSAAS-387 - snakeyaml-1.31 CVE-2022-38752(6.5) suppression

### DIFF
--- a/owasp/owasp-checker-suppressions.xml
+++ b/owasp/owasp-checker-suppressions.xml
@@ -23,4 +23,9 @@
         <packageUrl regex="true">^pkg:maven/org\.springframework/spring.*$</packageUrl>
         <cve>CVE-2016-1000027</cve>
     </suppress>
+	<suppress>
+        <notes><![CDATA[file name: snakeyaml-1.31.jar]]></notes>
+         <packageUrl regex="true">^pkg:maven/org\.snakeyaml/snakeyaml@.*$</packageUrl>
+        <cve>CVE-2022-38752</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
[ERROR] One or more dependencies were identified with vulnerabilities that have a CVSS score greater than or equal to '1.0': [ERROR] [ERROR] snakeyaml-1.31.jar: CVE-2022-38752(6.5)

JIRA: https://payex.atlassian.net/browse/FPSAAS-387