### PR TITLE
FPSAAS-387: Adding suppression for snakeyaml.

### DIFF
--- a/owasp/owasp-checker-suppressions.xml
+++ b/owasp/owasp-checker-suppressions.xml
@@ -25,7 +25,7 @@
     </suppress>
 	<suppress>
         <notes><![CDATA[file name: snakeyaml-1.31.jar]]></notes>
-         <packageUrl regex="true">^pkg:maven/org\.snakeyaml/snakeyaml@.*$</packageUrl>
+        <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
         <cve>CVE-2022-38752</cve>
     </suppress>
 </suppressions>


### PR DESCRIPTION
Snakeyaml 1.31 has a medium vulberbility causing the commons repo build to fail.

[ERROR] One or more dependencies were identified with vulnerabilities that have a CVSS score greater than or equal to '1.0': [ERROR] [ERROR] snakeyaml-1.31.jar: CVE-2022-38752(6.5)