### PR TITLE
Removing suppression for SnakeYaml

### DIFF
--- a/owasp/owasp-checker-suppressions.xml
+++ b/owasp/owasp-checker-suppressions.xml
@@ -23,9 +23,4 @@
         <packageUrl regex="true">^pkg:maven/org\.springframework/spring.*$</packageUrl>
         <cve>CVE-2016-1000027</cve>
     </suppress>
-	<suppress>
-        <notes><![CDATA[file name: snakeyaml-1.31.jar]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
-        <cve>CVE-2022-38752</cve>
-    </suppress>
 </suppressions>


### PR DESCRIPTION
Snake yaml 1.32 has been released which fixes the CVE in 1.31. Removing the suppression