### PR TITLE
Added copyright file and removed suppressions

### DIFF
--- a/copyright/copyright.cpr
+++ b/copyright/copyright.cpr
@@ -5,7 +5,6 @@
  * referenced, shared or handled by explicit permission and authorization
  * of the GlobalPayEx leadership team @ https://www.globalpayex.com/about-us/the-company/.
  * 
- *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/copyright/copyright.cpr
+++ b/copyright/copyright.cpr
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2016-2022 GlobalPayEx @ https://globalpayex.com
+ *   Copyright 2016 - $YEAR GlobalPayEx @ https://globalpayex.com
  *
  * This file and all its contents are proprietary and to be used, 
  * referenced, shared or handled by explicit permission and authorization
@@ -11,3 +11,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+

--- a/copyright/copyright.cpr
+++ b/copyright/copyright.cpr
@@ -1,0 +1,14 @@
+/*
+ *   Copyright 2016-2022 GlobalPayEx @ https://globalpayex.com
+ *
+ * This file and all its contents are proprietary and to be used, 
+ * referenced, shared or handled by explicit permission and authorization
+ * of the GlobalPayEx leadership team @ https://www.globalpayex.com/about-us/the-company/.
+ * 
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/owasp/owasp-checker-suppressions.xml
+++ b/owasp/owasp-checker-suppressions.xml
@@ -18,14 +18,9 @@
 -->
 
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-    <!-- <suppress>
-        <notes><![CDATA[Ignored since we are not vulnerable]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.springframework/spring.*$</packageUrl>
-        <cve>CVE-2016-1000027</cve>
-    </suppress>
     <suppress>
         <notes><![CDATA[file name: snakeyaml-1.32.jar - https://bitbucket.org/snakeyaml/snakeyaml/issues/551/snakeyaml-cves]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
         <cve>CVE-2022-38752</cve>
-    </suppress> -->
+    </suppress>
 </suppressions>

--- a/owasp/owasp-checker-suppressions.xml
+++ b/owasp/owasp-checker-suppressions.xml
@@ -18,7 +18,7 @@
 -->
 
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-    <suppress>
+    <!-- <suppress>
         <notes><![CDATA[Ignored since we are not vulnerable]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.springframework/spring.*$</packageUrl>
         <cve>CVE-2016-1000027</cve>
@@ -27,5 +27,5 @@
         <notes><![CDATA[file name: snakeyaml-1.32.jar - https://bitbucket.org/snakeyaml/snakeyaml/issues/551/snakeyaml-cves]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
         <cve>CVE-2022-38752</cve>
-    </suppress>
+    </suppress> -->
 </suppressions>


### PR DESCRIPTION
### Suppressions:
Spring 5.3.23 has been released to replace 5.3.22 with CVE 
SnakeYaml 1.32 has been corrected in CVE database as it is not vulnerable (https://github.com/github/advisory-database/pull/667)

### Copyright: Full message - 
/*
 *   Copyright 2016-2022 GlobalPayEx @ https://globalpayex.com
 *
 * This file and all its contents are proprietary and to be used, 
 * referenced, shared or handled by explicit permission and authorization
 * of the GlobalPayEx leadership team @ https://www.globalpayex.com/about-us/the-company/.
 * 
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */